### PR TITLE
Fixes #3 with numbers disappearing in Chrome

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -37,7 +37,7 @@ $('body').on('click', '.vertical .arrow.top', () => {
     .add({
       targets: '.vertical .box > div:not(.active) span',
       translateY: 0,
-      delay: anime.stagger(eachNumberDelay),
+      delay: anime.stagger(eachNumberDelay*2),
       duration: speed
     }, '-=' + speed * 1.06);
   
@@ -75,7 +75,7 @@ $('body').on('click', '.vertical .arrow.bottom', () => {
     .add({
       targets: '.vertical .box > div:not(.active) span',
       translateY: 0,
-      delay: anime.stagger(eachNumberDelay),
+      delay: anime.stagger(eachNumberDelay*2),
       duration: speed
     }, '-=' + speed * 1.06);
   


### PR DESCRIPTION
This fixes #3 in Chrome for me.

I am not sure why this worked but I believe it had something to do with the delay on changing the `translateY` CSS for the vertical stepper only. Instead of having a `translateY: 0;` set for the final number, it was setting it to +/- 95 to hide BOTH sets of numbers. 

Increasing  the delay by double fixed the issue for me and there is no noticeable animation problems. No changes were required on the horizontal stepper. 